### PR TITLE
Fix Travis CI URLs to use travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ PARTICULAR PURPOSE. See the [GNU Lesser General Public License] for more details
 
 [crate-image]: https://img.shields.io/crates/v/librpm.svg
 [crate-link]: https://crates.io/crates/librpm
-[build-image]: https://travis-ci.com/rpm-software-management/librpm.rs.svg?branch=master
-[build-link]: https://travis-ci.com/rpm-software-management/librpm.rs/
+[build-image]: https://travis-ci.org/rpm-software-management/librpm.rs.svg?branch=master
+[build-link]: https://travis-ci.org/rpm-software-management/librpm.rs/
 [license-image]: https://img.shields.io/badge/license-LGPLv2.1+-blue.svg
 [license-link]: https://github.com/rpm-software-management/librpm.rs/blob/master/COPYING
 

--- a/librpm-sys/README.md
+++ b/librpm-sys/README.md
@@ -36,8 +36,8 @@ PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
 [crate-image]: https://img.shields.io/crates/v/librpm-sys.svg
 [crate-link]: https://crates.io/crates/librpm-sys
-[build-image]: https://travis-ci.com/rpm-software-management/librpm.rs.svg?branch=master
-[build-link]: https://travis-ci.com/rpm-software-management/librpm.rs/
+[build-image]: https://travis-ci.org/rpm-software-management/librpm.rs.svg?branch=master
+[build-link]: https://travis-ci.org/rpm-software-management/librpm.rs/
 [license-image]: https://img.shields.io/badge/license-LGPLv2.1+-blue.svg
 [license-link]: https://github.com/iqlusion-io/crates/blob/master/LICENSE
 

--- a/librpmbuild-sys/README.md
+++ b/librpmbuild-sys/README.md
@@ -31,8 +31,8 @@ PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
 [crate-image]: https://img.shields.io/crates/v/librpmbuild-sys.svg
 [crate-link]: https://crates.io/crates/librpmbuild-sys
-[build-image]: https://travis-ci.com/rpm-software-management/librpm.rs.svg?branch=master
-[build-link]: https://travis-ci.com/rpm-software-management/librpm.rs/
+[build-image]: https://travis-ci.org/rpm-software-management/librpm.rs.svg?branch=master
+[build-link]: https://travis-ci.org/rpm-software-management/librpm.rs/
 [license-image]: https://img.shields.io/badge/license-LGPLv2.1+-blue.svg
 [license-link]: https://github.com/iqlusion-io/crates/blob/master/LICENSE
 

--- a/librpmsign-sys/README.md
+++ b/librpmsign-sys/README.md
@@ -31,8 +31,8 @@ PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
 [crate-image]: https://img.shields.io/crates/v/librpmsign-sys.svg
 [crate-link]: https://crates.io/crates/librpmsign-sys
-[build-image]: https://travis-ci.com/rpm-software-management/librpm.rs.svg?branch=master
-[build-link]: https://travis-ci.com/rpm-software-management/librpm.rs/
+[build-image]: https://travis-ci.org/rpm-software-management/librpm.rs.svg?branch=master
+[build-link]: https://travis-ci.org/rpm-software-management/librpm.rs/
 [license-image]: https://img.shields.io/badge/license-LGPLv2.1+-blue.svg
 [license-link]: https://github.com/iqlusion-io/crates/blob/master/LICENSE
 


### PR DESCRIPTION
In the RPM Software Management organization, we're still using
travis-ci.org instead of travis-ci.com.