### PR TITLE
error: fix compiler warning for 'fail' macro

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -72,9 +72,9 @@ macro_rules! format_err {
 /// Create and return an error enum variant with a formatted message
 macro_rules! fail {
     ($kind:path, $msg:expr) => {
-        return Err(format_err!($kind, $msg));
+        return Err(format_err!($kind, $msg))
     };
     ($kind:path, $fmt:expr, $($arg:tt)+) => {
-        return Err(format_err!($kind, $fmt, $($arg)+));
+        return Err(format_err!($kind, $fmt, $($arg)+))
     };
 }


### PR DESCRIPTION
The macro 'fail' inject a trailing semicolon during the expansion.  This
is considered deprecated and will be a hard fail in the next rustc
release:

https://github.com/rust-lang/rust/issues/79813