### PR TITLE
Address clippy complains

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -64,18 +64,6 @@ impl Index {
     }
 }
 
-impl Into<Tag> for Index {
-    fn into(self) -> Tag {
-        match self {
-            Index::Name => Tag::NAME,
-            Index::Version => Tag::VERSION,
-            Index::License => Tag::LICENSE,
-            Index::Summary => Tag::SUMMARY,
-            Index::Description => Tag::DESCRIPTION,
-        }
-    }
-}
-
 /// Find all packages installed on the local system.
 pub fn installed_packages() -> Iter {
     Iter(MatchIterator::new(Tag::NAME, None))

--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -2,7 +2,6 @@
 
 use super::{tag::Tag, td::TagData};
 use crate::{License, Package, Version};
-use librpm_sys;
 use std::mem;
 
 /// RPM package header

--- a/src/internal/iterator.rs
+++ b/src/internal/iterator.rs
@@ -1,7 +1,6 @@
 //! Iterators for matches in the RPM database
 
 use super::{header::Header, tag::Tag, ts::GlobalTS};
-use librpm_sys;
 #[cfg(feature = "regex")]
 use regex::Regex;
 use std::{os::raw::c_void, ptr};

--- a/src/internal/tag.rs
+++ b/src/internal/tag.rs
@@ -1,8 +1,8 @@
 //! Tags are identifiers for RPM headers
 
-#![allow(dead_code, missing_docs, non_camel_case_types)]
+#![allow(dead_code, missing_docs, non_camel_case_types, clippy::upper_case_acronyms)]
 
-use librpm_sys;
+use crate::Index;
 
 /// Identifiers for data in RPM headers (`rpmTag_e` in librpm)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -251,6 +251,18 @@ pub enum Tag {
     OBSOLETENEVRS = librpm_sys::rpmTag_e_RPMTAG_OBSOLETENEVRS as isize,
     CONFLICTNEVRS = librpm_sys::rpmTag_e_RPMTAG_CONFLICTNEVRS as isize,
     FILENLINKS = librpm_sys::rpmTag_e_RPMTAG_FILENLINKS as isize,
+}
+
+impl From<Index> for Tag {
+    fn from(i: Index) -> Self {
+        match i {
+            Index::Name => Tag::NAME,
+            Index::Version => Tag::VERSION,
+            Index::License => Tag::LICENSE,
+            Index::Summary => Tag::SUMMARY,
+            Index::Description => Tag::DESCRIPTION,
+        }
+    }
 }
 
 /// RPM database index tags (`rpmDbiTag_e` in librpm)

--- a/src/internal/td.rs
+++ b/src/internal/td.rs
@@ -4,7 +4,6 @@
 #![allow(dead_code)]
 
 use super::tag::TagType;
-use librpm_sys;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::{slice, str};
@@ -126,10 +125,7 @@ impl<'hdr> TagData<'hdr> {
 
     /// Is this tag data NULL?
     pub fn is_null(&self) -> bool {
-        match *self {
-            TagData::Null => true,
-            _ => false,
-        }
+	matches!(*self, TagData::Null)
     }
 
     /// Obtain a char value, if this is a char

--- a/src/internal/ts.rs
+++ b/src/internal/ts.rs
@@ -1,7 +1,6 @@
 //! Transaction sets: librpm's transaction API
 
 use super::GlobalState;
-use librpm_sys;
 use std::sync::atomic::AtomicPtr;
 use std::sync::MutexGuard;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,8 +5,8 @@ use std::sync::Once;
 
 /// The `.rpm` containing librpm itself
 const PACKAGE_NAME: &str = "rpm-devel";
-const PACKAGE_SUMMARY: &str = "Development files for manipulating RPM packages";
-const PACKAGE_LICENSE: &str = "GPLv2+ and LGPLv2+ with exceptions";
+const PACKAGE_SUMMARY: &str = "Development files for librpm";
+const PACKAGE_LICENSE: &str = "GPL-2.0-or-later";
 
 static CONFIGURE: Once = Once::new();
 


### PR DESCRIPTION
I think that most of the changes are OK, but maybe special attention to:

* New clippy::upper_case_acronyms allow lint. IMHO this should be dropped and the enums alternatives should follow the rust naming convention, instead of being a replica of the exported symbols
* Move the "impl Into" for Index as a "impl From" in Tag.