### PR TITLE
build: replace blacklist_type with blocklist_type

### DIFF
--- a/librpm-sys/build.rs
+++ b/librpm-sys/build.rs
@@ -24,7 +24,7 @@ fn main() {
     // TODO: whitelist types and functions we actually use
     let builder = Builder::default()
         .header("include/librpm.hpp")
-        .blacklist_type("timex");
+        .blocklist_type("timex");
 
     // Write generated bindings to OUT_DIR (to be included in the crate)
     let output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("binding.rs");

--- a/librpmbuild-sys/build.rs
+++ b/librpmbuild-sys/build.rs
@@ -10,7 +10,7 @@ fn main() {
     // TODO: whitelist types and functions we actually use
     let builder = Builder::default()
         .header("include/librpmbuild.hpp")
-        .blacklist_type("timex");
+        .blocklist_type("timex");
 
     // Write generated bindings to OUT_DIR (to be included in the crate)
     let output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("binding.rs");


### PR DESCRIPTION
blacklist_type() method of builder has been deprecated, and replaced
with blocklist_type.

Signed-off-by: Alberto Planas <aplanas@suse.com>