### PR TITLE
package: make arch optional

### DIFF
--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -60,7 +60,7 @@ impl Header {
             epoch: self.get(Tag::EPOCH).map(|d| d.as_str().unwrap().to_owned()),
             version: self.get(Tag::VERSION).unwrap().as_str().unwrap().to_owned(),
             release: self.get(Tag::RELEASE).unwrap().as_str().unwrap().to_owned(),
-            arch: self.get(Tag::ARCH).unwrap().as_str().unwrap().to_owned(),
+            arch: self.get(Tag::ARCH).map(|d| d.as_str().unwrap().to_owned()),
             license: self.get(Tag::LICENSE).unwrap().as_str().unwrap().to_owned(),
             summary: self.get(Tag::SUMMARY).unwrap().as_str().unwrap().into(),
             description: self.get(Tag::DESCRIPTION).unwrap().as_str().unwrap().into(),

--- a/src/package.rs
+++ b/src/package.rs
@@ -17,7 +17,7 @@ pub struct Package {
     pub(crate) release: String,
 
     /// Arch of the package
-    pub(crate) arch: String,
+    pub(crate) arch: Option<String>,
 
     /// License of the package
     pub(crate) license: String,
@@ -46,8 +46,8 @@ impl Package {
         &self.release
     }
 
-    pub fn arch(&self) -> &str {
-        &self.arch
+    pub fn arch(&self) -> Option<&str> {
+        self.arch.as_ref().map(|s| s.as_str())
     }
 
     pub fn evr(&self) -> String {
@@ -59,7 +59,11 @@ impl Package {
     }
 
     pub fn nevra(&self) -> String {
-        format!("{}-{}.{}", self.name, self.evr(), self.arch)
+        if let Some(arch) = &self.arch {
+            format!("{}-{}.{}", self.name, self.evr(), arch)
+        } else {
+            format!("{}-{}", self.name, self.evr())
+        }
     }
 
     pub fn license(&self) -> &str {


### PR DESCRIPTION
In certain situations "arch" field can be optional.  One example are the
"gpg-pubkey" packages.

Signed-off-by: Alberto Planas <aplanas@suse.com>